### PR TITLE
Allow using the module in non-node projects

### DIFF
--- a/src/timeframe.js
+++ b/src/timeframe.js
@@ -1,4 +1,4 @@
-var TimeFrame = class {
+export default class {
     constructor() {
       this.date = this.unixChecker(arguments);
       this.startDate = Date.now();
@@ -100,7 +100,3 @@ var TimeFrame = class {
     }
   }
 
-if (typeof module !== 'undefined')
-{
-  module.exports = TimeFrame
-}

--- a/src/timeframe.js
+++ b/src/timeframe.js
@@ -1,4 +1,4 @@
-module.exports = class TimeFrame {
+var TimeFrame = class {
     constructor() {
       this.date = this.unixChecker(arguments);
       this.startDate = Date.now();
@@ -99,3 +99,8 @@ module.exports = class TimeFrame {
       }
     }
   }
+
+if (typeof module !== 'undefined')
+{
+  module.exports = TimeFrame
+}


### PR DESCRIPTION
Hi,
I wanted to use this library in my gnome-shell extension, but this uses gjs instead of node, so the "module.exports" does not work (and breaks, because module is undefined).
This small change should make it work in gjs and the unit tests still work, so I guess node is fine still (I'm not a node expert, so please check)

Best regards,
Bart